### PR TITLE
Add missing tournaments (+ fix wrong link to ARCADIA)

### DIFF
--- a/2022.md
+++ b/2022.md
@@ -4,4 +4,4 @@ year: "2022"
 title: 2022–2023 season
 ---
 
-Last updated on July 17, 2022.
+Last updated on July 19, 2022.

--- a/_data/sets/2022/easy3.yaml
+++ b/_data/sets/2022/easy3.yaml
@@ -1,0 +1,10 @@
+slot:        Spring Novice
+prev:        [Spring Novice, Boilermaker Spring Novice]
+diff:        Easy
+diffdots:    ●
+eligible:    Closed; scoring limits
+name:        Canadian Novice
+firstmirror: March 2023
+speculative: Yes
+announced:   2022-07-19
+announceurl: https://hsquizbowl.org/forums/viewtopic.php?t=26114

--- a/_data/sets/2022/medium2.yaml
+++ b/_data/sets/2022/medium2.yaml
@@ -7,4 +7,4 @@ producedby:  UNC and Duke
 fullname:    A Regs-minus Carolina and Duke Invitational of Academia
 firstmirror: TBD
 announced:   2022-04-22
-announceurl: https://hsquizbowl.org/forums/viewtopic.php?t=25977
+announceurl: https://hsquizbowl.org/forums/viewtopic.php?t=25820

--- a/_data/sets/2022/regionals5.yaml
+++ b/_data/sets/2022/regionals5.yaml
@@ -1,0 +1,12 @@
+slot:        “Spring Regionals 2”
+prev:        [past ACF Regionals]
+diff:        Regionals
+diffdots:    ●●●
+eligible:    Closed
+name:        IQBT UG Champs
+full_name:   IQBT Undergraduate Championship
+announced:   2022-04-27
+announceurl: https://hsquizbowl.org/forums/viewtopic.php?t=25986
+firstmirror: 2023-03-04
+mirrors:
+  - { date: 2023-03-04, eligible: Undergraduate, url: "https://hsquizbowl.org/forums/viewtopic.php?t=25986" }

--- a/_data/sets/2022/seasons.yaml
+++ b/_data/sets/2022/seasons.yaml
@@ -21,5 +21,7 @@
     - regionals2
     - medium4
     - open2
+    - regionals5
+    - easy3
     - nationals2
     - nationals1


### PR DESCRIPTION
Quick update to add IQBT's undergraduate championship and the newly-announced Canadian novice tournament.