### PR TITLE
Update Planetfall IV, Terrapin Open, BUZZKILL info

### DIFF
--- a/2026.md
+++ b/2026.md
@@ -4,4 +4,4 @@ year: "2026"
 title: 2026–2027 season
 ---
 
-Last updated on July 29, 2026.
+Last updated on August 1, 2026.

--- a/_data/sets/2026/easy4.yaml
+++ b/_data/sets/2026/easy4.yaml
@@ -10,3 +10,4 @@ announceurl: https://hsquizbowl.org/forums/viewtopic.php?t=30303
 firstmirror: 2026-10-03
 mirrors:
   - { date: 2026-10-03, region: 3A, name: Vanderbilt, url: https://hsquizbowl.org/forums/viewtopic.php?t=30336 }
+  - { date: 2026-10-24, region: 3A, name: USN, eligible: HS }

--- a/_data/sets/2026/easy4.yaml
+++ b/_data/sets/2026/easy4.yaml
@@ -3,10 +3,10 @@ fullname:    "Planetfall IV: Dysnomia"
 producedby:  USN
 slot:        “Fall Easy 2”
 diff:        Easy
-diffdots:    ●
+diffdots:    ●◖
 eligible:    HS-only mirrors
-prev:        [past Planetfalls, past ACF Falls]
 announced:   2026-07-15
 announceurl: https://hsquizbowl.org/forums/viewtopic.php?t=30303
 firstmirror: 2026-10-03
 mirrors:
+  - { date: 2026-10-03, region: 3A, name: Vanderbilt, url: https://hsquizbowl.org/forums/viewtopic.php?t=30336 }

--- a/_data/sets/2026/medium7.yaml
+++ b/_data/sets/2026/medium7.yaml
@@ -1,8 +1,10 @@
 name:        BUZZKILL
+fullname:    "By Unserious Zany Zealots: Knowledge Involves Loving Learning"
 producedby:  Georgia Tech
 slot:        “Fall Medium”
 diff:        Medium
 diffdots:    ●●
+prev:        [past ACF Winters, past MRNAs]
 announced:   2026-07-28
 announceurl: https://hsquizbowl.org/forums/viewtopic.php?t=30328
 firstmirror: November 2026

--- a/_data/sets/2026/open1.yaml
+++ b/_data/sets/2026/open1.yaml
@@ -15,6 +15,6 @@ mirrors:
   - { date: 2026-09-12, region: 2A, name: Maryland, url: https://hsquizbowl.org/forums/viewtopic.php?t=30253 }
   - { date: 2026-09-12, region: 1A, name: Boston }
   - { date: 2026-09-26, region: 3B, name: Georgia Tech, url: https://hsquizbowl.org/forums/viewtopic.php?t=30326 }
-  - { date: 2026-10-03, region: 4A, nae: Texas }
+  - { date: 2026-10-03, region: 4A, name: Texas }
   - { date: 2026-10-24, region: 8B, name: Chicago, url: https://hsquizbowl.org/forums/viewtopic.php?t=30327 }
   - { date: TBD, region: 0L, name: Online }

--- a/_data/sets/2026/open1.yaml
+++ b/_data/sets/2026/open1.yaml
@@ -15,5 +15,6 @@ mirrors:
   - { date: 2026-09-12, region: 2A, name: Maryland, url: https://hsquizbowl.org/forums/viewtopic.php?t=30253 }
   - { date: 2026-09-12, region: 1A, name: Boston }
   - { date: 2026-09-26, region: 3B, name: Georgia Tech, url: https://hsquizbowl.org/forums/viewtopic.php?t=30326 }
+  - { date: 2026-10-03, region: 4A, nae: Texas }
   - { date: 2026-10-24, region: 8B, name: Chicago, url: https://hsquizbowl.org/forums/viewtopic.php?t=30327 }
   - { date: TBD, region: 0L, name: Online }


### PR DESCRIPTION
- Updated Planetfall IV diff to 1.5 dots, added Vanderbilt & mainsite (USN) mirrors 
- Added Texas mirror to Terrapin Open 
- Added full name & prevs to BUZZKILL