### PR TITLE
Update CLOPEN and Terrapin Open mirrors

### DIFF
--- a/2026.md
+++ b/2026.md
@@ -4,4 +4,4 @@ year: "2026"
 title: 2026–2027 season
 ---
 
-Last updated on August 12, 2026.
+Last updated on August 13, 2026.

--- a/_data/sets/2026/open1.yaml
+++ b/_data/sets/2026/open1.yaml
@@ -13,7 +13,7 @@ firstideal:  2026-09-01
 lastideal:   2026-09-30
 mirrors: 
   - { date: 2026-09-12, region: 2A, name: Maryland, url: https://hsquizbowl.org/forums/viewtopic.php?t=30253 }
-  - { date: 2026-09-12, region: 1A, name: Boston, url: https://hsquizbowl.org/forums/viewtopic.php?t=30383 }
+  - { date: 2026-09-12, region: 1A, name: Boston University, url: https://hsquizbowl.org/forums/viewtopic.php?t=30383 }
   - { date: 2026-09-26, region: 3B, name: Georgia Tech, url: https://hsquizbowl.org/forums/viewtopic.php?t=30326 }
   - { date: 2026-09-26, region: UK, name: Manchester }
   - { date: 2026-10-03, region: 4A, name: Texas }

--- a/_data/sets/2026/open2.yaml
+++ b/_data/sets/2026/open2.yaml
@@ -7,4 +7,6 @@ diffdots:    ●●●
 prev:        [past ACF Regionals]
 announced:   2026-01-27
 announceurl: https://hsquizbowl.org/forums/viewtopic.php?t=29807
+firstmirror: 2026-11-21
 mirrors:
+  - { date: 2026-11-21, region: 2A, name: Columbia, eligible: Closed }


### PR DESCRIPTION
- Added CLOPEN @ Columbia (mainsite, closed); a forums post/more info is "forthcoming"
- Updated site name of Terrapin Open @ BU to "Boston University," as "Boston" wasn't appearing on the map in local testing & is not a listed alias of BU in `map/colleges.tsv`